### PR TITLE
Fix config validation exceptions

### DIFF
--- a/DependencyInjection/Compiler/ValidateExtensionConfigurationPass.php
+++ b/DependencyInjection/Compiler/ValidateExtensionConfigurationPass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class ValidateExtensionConfigurationPass implements CompilerPassInterface
+{
+
+    /**
+     * Validate the DoctrineExtensions DIC extension config.
+     *
+     * This validation runs in a discrete compiler pass because it depends on
+     * DBAL and ODM services, which aren't available during the config merge
+     * compiler pass.
+     *
+     * @param ContainerBuilder $container
+     * @return void
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $container->getExtension('stof_doctrine_extensions')->configValidate($container);
+    }
+
+}

--- a/StofDoctrineExtensionsBundle.php
+++ b/StofDoctrineExtensionsBundle.php
@@ -3,9 +3,21 @@
 namespace Stof\DoctrineExtensionsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler\ValidateExtensionConfigurationPass;
 
 class StofDoctrineExtensionsBundle extends Bundle
 {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerExtensions(ContainerBuilder $container)
+    {
+        parent::registerExtensions($container);
+        $container->addCompilerPass(new ValidateExtensionConfigurationPass());
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Remove DBAL connection and Document Manager config validation from DIC config load. This will need to be done in another compiler pass.

I'm working on a compiler pass implementation. I'll add it to this request if I get it done before you pull.
