### PR TITLE
Fix ODM issue on integer type

### DIFF
--- a/Resources/config/doctrine/Stof.DoctrineExtensionsBundle.Document.AbstractLogEntry.mongodb.xml
+++ b/Resources/config/doctrine/Stof.DoctrineExtensionsBundle.Document.AbstractLogEntry.mongodb.xml
@@ -16,7 +16,7 @@
 
         <field fieldName="objectClass" type="string" index="true" />
 
-        <field fieldName="version" type="integer" />
+        <field fieldName="version" type="int" />
 
         <field fieldName="data" type="string" nullable="true" />
 


### PR DESCRIPTION
The type integer gives the following error on ODM while warming up the cache:

<pre>
[InvalidArgumentException]
Invalid type specified "integer".
</pre>

This fixes that issue.
