### PR TITLE
Add a call to setTranslatableLocale in listeners.xml

### DIFF
--- a/Resources/config/listeners.xml
+++ b/Resources/config/listeners.xml
@@ -24,6 +24,9 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setTranslatableLocale">
+                <argument>%stof_doctrine_extensions.default_locale%</argument>
+            </call>
             <call method="setDefaultLocale">
                 <argument>%stof_doctrine_extensions.default_locale%</argument>
             </call>


### PR DESCRIPTION
Hi, It will be nice to set the property in TranslationListener::locale on listener initialization.
I've just added a call to "TranslationListener::setTranslatableLocale" in "listeners.xml" DIC config file, using as parameter "%stof_doctrine_extensions.default_locale%"

Maybe there is some other way to set a default locale. It seems to me a good idea to have it set on TranslationListener initialization.

Regards
