### PR TITLE
Invalid mongodb mapping for loggable extension

### DIFF
--- a/Resources/config/doctrine/AbstractLogEntry.mongodb.xml
+++ b/Resources/config/doctrine/AbstractLogEntry.mongodb.xml
@@ -18,7 +18,7 @@
 
         <field fieldName="version" type="int" />
 
-        <field fieldName="data" type="string" nullable="true" />
+        <field fieldName="data" type="hash" nullable="true" />
 
         <field fieldName="username" type="string" nullable="true" index="true" />
 


### PR DESCRIPTION
AbstractLogEntry::$data must be mapped as "hash" not as "string" for MongoDB ODM (same as in original library: https://github.com/l3pp4rd/DoctrineExtensions/blob/master/lib/Gedmo/Loggable/Document/AbstractLogEntry.php)
