### PR TITLE
Changed call to Request::getLocale()

### DIFF
--- a/Listener/TranslationListener.php
+++ b/Listener/TranslationListener.php
@@ -35,6 +35,6 @@ class TranslationListener extends BaseTranslationListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        $this->setTranslatableLocale($event->getRequest()->getLocale());
+        $this->setTranslatableLocale($event->getRequest()->getSession()->getLocale());
     }
 }


### PR DESCRIPTION
Tried using the Translatable behavior, but always got error underneath. I have tried with Symfony 2.0.3, 2.0.4 and 2.0.5.

Fatal error: Call to undefined method Symfony\Component\HttpFoundation\Request::getLocale()
