### PR TITLE
It works the same (because Gedmo\Loggable\LoggableListener::setUsername ...

### DIFF
--- a/Listener/LoggableListener.php
+++ b/Listener/LoggableListener.php
@@ -35,7 +35,7 @@ class LoggableListener extends BaseLoggableListener implements ContainerAwareInt
     {
         $securityContext = $this->container->get('security.context', ContainerInterface::NULL_ON_INVALID_REFERENCE);
         if (null !== $securityContext && null !== $securityContext->getToken() && $securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
-            $this->setUsername($securityContext->getToken()->getUsername());
+            $this->setUsername($securityContext->getToken());
         }
     }
 


### PR DESCRIPTION
...detects if the param is an object and has getUsername method than uses it), but now I can save for example ID or email in Gedmo.
