### PR TITLE
Change of event subscriber tag for mongodb

### DIFF
--- a/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -56,7 +56,7 @@ class StofDoctrineExtensionsExtension extends Extension
                         $useLoggable = true;
                     }
                     $definition = $container->getDefinition($listener);
-                    $definition->addTag(sprintf('doctrine.odm.mongodb.%s_event_subscriber', $name));
+                    $definition->addTag('doctrine.odm.mongodb.event_subscriber', array('connection' => $name));
                 }
             }
             $this->documentManagers[$name] = $listeners;


### PR DESCRIPTION
Use the new event subscriber tag for mongodb ( `doctrine.odm.mongodb.{connection}_event_subscriber` doesnt work anymore ).

See the "Registering Event Listeners and Subscribers" section: https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/Resources/doc/index.rst
