### PR TITLE
[doc] Wrong path in documentation leads to "unknown mapping"

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -42,16 +42,18 @@ Bring in the vendor libraries
 
 This can be done in two different ways:
 
-**Method #1**) Use the bin/vendor script
+**Method #1**) Use composer
 
 ::
 
-    [gedmo-doctrine-extensions]
-        git=http://github.com/l3pp4rd/DoctrineExtensions.git
+    "require": {
+        "php": ">=5.3.2",
+        "symfony/symfony": "2.1.*",
+        "_comment":"your ther packages",
 
-    [StofDoctrineExtensionsBundle]
-        git=http://github.com/stof/StofDoctrineExtensionsBundle.git
-        target=/bundles/Stof/DoctrineExtensionsBundle
+        "stof/doctrine-extensions-bundle":"dev-master",
+    }
+
 
 **Method #2**) Use git submodules
 
@@ -62,6 +64,8 @@ This can be done in two different ways:
 
 Register the DoctrineExtensions and Stof namespaces
 ---------------------------------------------------
+
+Only required, when using submodules.
 
 ::
 


### PR DESCRIPTION
Took me some time to find the issue, after I upgraded to Symfony2.1 :)
