### PR TITLE
fix translatable listener defaut locale

### DIFF
--- a/Resources/config/listeners.xml
+++ b/Resources/config/listeners.xml
@@ -27,6 +27,9 @@
             <call method="setDefaultLocale">
                 <argument>%stof_doctrine_extensions.default_locale%</argument>
             </call>
+            <call method="setTranslatableLocale">
+                <argument>%stof_doctrine_extensions.default_locale%</argument>
+            </call>
             <call method="setTranslationFallback">
                 <argument>%stof_doctrine_extensions.translation_fallback%</argument>
             </call>


### PR DESCRIPTION
The service definition now sets the default locale of the user as the translatable locale that should be used by  TranslatableListener at startup.

This is useful for CLI commands so they can now assume at least the default locale is used as the translatable locale.

This address GH-110.
