### PR TITLE
Adding a getter for uploadable listener.

### DIFF
--- a/Uploadable/UploadableManager.php
+++ b/Uploadable/UploadableManager.php
@@ -38,11 +38,11 @@ class UploadableManager
     }
     
     /**
-	 * @return \Gedmo\Uploadable\UploadableListener
-	 */
-	public function getUploadableListener()
-	{
-		return $this->listener;
-	}
-    
+     * @return \Gedmo\Uploadable\UploadableListener
+     */
+    public function getUploadableListener()
+    {
+        return $this->listener;
+    }
+
 }


### PR DESCRIPTION
This is to allow easily adding default path and other parameters directly from the service.

e.g.

```
    $uploadableManager = $this->get('stof_doctrine_extensions.uploadable.manager');
    $uploadableManager->getListener()->setDefaultPath('media/products');
    $uploadableManager->markEntityToUpload($entity, $entity->getFile());
```
