### PR TITLE
Allow to configure Sluggable managed filters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration implements ConfigurationInterface
             ->append($this->getVendorNode('mongodb'))
             ->append($this->getClassNode())
             ->append($this->getUploadableNode())
+            ->append($this->getSluggableNode())
             ->children()
                 ->scalarNode('default_locale')
                     ->cannotBeEmpty()
@@ -140,6 +141,28 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('Stof\\DoctrineExtensionsBundle\\Uploadable\\UploadedFileInfo')
                 ->end()
                 ->booleanNode('validate_writable_directory')->defaultTrue()->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function getSluggableNode()
+    {
+        $treeBuilder = new TreeBuilder();
+        $node = $treeBuilder->root('sluggable');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('managed_filters')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('disabled')->defaultValue(true)->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -120,6 +120,15 @@ class StofDoctrineExtensionsExtension extends Extension
             );
         }
 
+        $sluggableConfig = $config['sluggable'];
+
+        if ($sluggableConfig['managed_filters']) {
+            $sluggableListener = $container->getDefinition('stof_doctrine_extensions.listener.sluggable');
+            foreach ($sluggableConfig['managed_filters'] as $filter => $settings) {
+                $sluggableListener->addMethodCall('addManagedFilter', array($filter, $settings['disabled']));
+            }
+        }
+
         foreach ($config['class'] as $listener => $class) {
             $container->setParameter(sprintf('stof_doctrine_extensions.listener.%s.class', $listener), $class);
         }

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -220,6 +220,12 @@ in YAML::
 
             # Default file info class implementing FileInfoInterface: Optional. By default we provide a class which is prepared to receive an UploadedFile instance.
             default_file_info_class: Stof\DoctrineExtensionsBundle\Uploadable\UploadedFileInfo
+	# Only used if you activate the Sluggable extension
+        sluggable:
+            # Allows the Sluggable listener to be configured with a set of filters to enable or disable prior to slug generation
+            managed_filters:
+                # Whether to use softdeletable filter when generating slug
+                softdeleteable: { disabled: true } # if null, filter will be disabled
         orm:
             default: ~
         mongodb:


### PR DESCRIPTION
This change allows to configure managed filters in Sluggable listener.

This is useful in case you are having issues with using Sluggable + Softdeleteable + Unique ( l3pp4rd/DoctrineExtensions#449 ).

Implementation suggested by @l3pp4rd in https://github.com/l3pp4rd/DoctrineExtensions/pull/549

This is PR https://github.com/stof/StofDoctrineExtensionsBundle/issues/185 by @stanislavprokopov reopened because of previous close. It is useful and should be merged into bundle.
