### PR TITLE
Added an option to disable Locale listener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('translation_fallback')->defaultFalse()->end()
                 ->booleanNode('persist_default_translation')->defaultFalse()->end()
                 ->booleanNode('skip_translation_on_load')->defaultFalse()->end()
+                ->booleanNode('use_request_locale')->defaultTrue()->end()
             ->end()
         ;
 

--- a/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -80,7 +80,7 @@ class StofDoctrineExtensionsExtension extends Extension
             $this->documentManagers[$name] = $listeners;
         }
 
-        if ($useTranslatable) {
+        if ($useTranslatable && $config['use_request_locale']) {
             $container->getDefinition('stof_doctrine_extensions.event_listener.locale')
                 ->setPublic(true)
                 ->addTag('kernel.event_subscriber');

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -226,6 +226,9 @@ the asked language. If you don't provide it explicitly, it will default to
         stof_doctrine_extensions:
             default_locale: en_US
 
+            # If you use Translatable extension, by default the Symfony2 current locale (from the Request) is used to fetch translated query results.
+            use_request_locale: true
+
             # Only used if you activated the Uploadable extension
             uploadable:
                 # Default file path: This is one of the three ways you can configure the path for the Uploadable extension


### PR DESCRIPTION
Hi,

In some case, using the Symfony2 locale (for example from the Request) to automatically filter entities using the `Translatable` extension can lead to unwanted results.
I came across such case in an application where the locale was already managed explicitly.

In this PR, we create an optional `disable_locale_listener` option. The default value is `true`, so there are no  BC break.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | ~ |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | Doc written |
