### PR TITLE
Updates Uploadable example for symfony 2.4

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -174,10 +174,10 @@ ready, use the form component as usual. Then, after you verify the form is valid
     ;
 
     if ($this->getRequest()->getMethod() === 'POST') {
-        $form->bindRequest($this->getRequest());
+        $form->bind($this->getRequest());
 
         if ($form->isValid()) {
-            $em = $this->getDoctrine()->getEntityManager();
+            $em = $this->getDoctrine()->getManager();
 
             $em->persist($document);
 


### PR DESCRIPTION
Form::bind is deprecated (and simply doesn't work any more) and getEntityManager is also deprecated (but still working).
