### PR TITLE
Add simple composer command for installation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -33,6 +33,12 @@ Installation
 Add stof/doctrine-extensions-bundle to composer.json
 -----------------------------
 
+.. code-block:: console
+
+    php composer.phar require stof/doctrine-extensions-bundle "~1.1@dev"
+
+or
+
 .. code-block:: json
 
     "require": {

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -30,14 +30,15 @@ See the official documentation_ for more details.
 Installation
 ============
 
-Add stof/doctrine-extensions-bundle to composer.json
+Install stof/doctrine-extensions-bundle
 -----------------------------
 
 .. code-block:: console
 
     php composer.phar require stof/doctrine-extensions-bundle "~1.1@dev"
 
-or
+Or add stof/doctrine-extensions-bundle to composer.json
+-----------------------------
 
 .. code-block:: json
 


### PR DESCRIPTION
Composer packages tend to propose the (not so new anymore) "composer require" method to install packages.