### PR TITLE
Bumb priority of the loggable listener

### DIFF
--- a/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -46,6 +46,7 @@ class StofDoctrineExtensionsExtension extends Extension
                         $attributes['priority'] = -10;
                     } elseif ('loggable' === $ext) {
                         $useLoggable = true;
+                        $attributes['priority'] = 5;
                     } elseif ('blameable' === $ext) {
                         $useBlameable = true;
                     } elseif ('uploadable' === $ext) {


### PR DESCRIPTION
Loggable and softdeleteable has priority 0 and softdeleteable happens before loggable so the remove is never logged.
Fixes #317
