### PR TITLE
Fixed a minor syntax issue in the docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -229,7 +229,7 @@ the asked language. If you don't provide it explicitly, it will default to
             # Only used if you activated the Uploadable extension
             uploadable:
                 # Default file path: This is one of the three ways you can configure the path for the Uploadable extension
-                default_file_path:       %kernel.root_dir%/../web/uploads
+                default_file_path:       "%kernel.root_dir%/../web/uploads"
 
                 # Mime type guesser class: Optional. By default, we provide an adapter for the one present in the HttpFoundation component of Symfony
                 mime_type_guesser_class: Stof\DoctrineExtensionsBundle\Uploadable\MimeTypeGuesserAdapter


### PR DESCRIPTION
As you can see at http://symfony.com/doc/current/bundles/StofDoctrineExtensionsBundle/index.html#configure-the-bundle this YAML config isn't highlighted because of this minor syntax issue.