### PR TITLE
Indication that Uploadable is not yet supported

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -26,7 +26,7 @@ DoctrineExtensions's features
 - **Sortable** - makes any document or entity sortable
 - **Translator** - explicit way to handle translations
 - **Softdeleteable** - allows to implicitly remove records
-- **Uploadable** - provides file upload handling in entity fields
+- **Uploadable** - provides file upload handling in entity fields - ODM is not yet supported.
 - **Reference Integrity** - provides reference integrity for MongoDB, supports
   ``nullify`` and ``restrict``.
 


### PR DESCRIPTION
Official documentation for ODM (https://github.com/Atlantic18/DoctrineExtensions#odm-mongodb-support) is saying that 'Uploadable' is not yet supported. It is worth mentioning here, in this documentation.
Possible issue reference:
`Notice: Undefined index: filePathField in Gedmo\Uploadable:127`
