### PR TITLE
Change filter name

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -132,7 +132,7 @@ to register their mapping in Doctrine when you want to use them.
     The mapping for MongoDB is similar. The ODM documents are in the ``Document``
     subnamespace of each extension instead of ``Entity``.
 
-Enable the ``softdeleteable`` filter
+Enable the ``soft-deleteable`` filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to use the SoftDeleteable behavior, you have to enable the
@@ -146,7 +146,7 @@ Doctrine filter.
             entity_managers:
                 default:
                     filters:
-                        softdeleteable:
+                        soft-deleteable:
                             class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
                             enabled: true
 
@@ -166,7 +166,7 @@ disable the filter. Here is an example:
 .. code-block:: php
 
     $filters = $em->getFilters();
-    $filters->disable('softdeleteable');
+    $filters->disable('soft-deleteable');
 
 Using ``Uploadable`` extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi,

Official docs use a name `softdeleteable`, but in this documentation is used another name.
http://atlantic18.github.io/DoctrineExtensions/doc/softdeleteable.html
This is confusing for a beginner and I believe that the required uniformity

Example: https://github.com/Atlantic18/DoctrineExtensions/pull/1660#issuecomment-247300241
