### PR TITLE
Upgrade of gedmo/doctine-extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.1|~3.0",
-        "gedmo/doctrine-extensions": "^2.3.1"
+        "gedmo/doctrine-extensions": "^2.4"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "to use the ORM extensions",


### PR DESCRIPTION
Documentation in dev-master is for 3.0 and we shoud be able update it.
https://github.com/Atlantic18/DoctrineExtensions/blob/master/UPGRADE-3.0.md
