### PR TITLE
Delay the static configuration of the file validator as late as possible

### DIFF
--- a/Resources/config/uploadable.xml
+++ b/Resources/config/uploadable.xml
@@ -12,6 +12,7 @@
     </parameters>
     <services>
         <service id="stof_doctrine_extensions.listener.uploadable" class="%stof_doctrine_extensions.listener.uploadable.class%" public="false">
+            <configurator service="stof_doctrine_extensions.uploadable.configurator" method="configure" />
             <argument type="service" id="stof_doctrine_extensions.uploadable.mime_type_guesser" />
 
             <call method="setAnnotationReader">
@@ -31,5 +32,9 @@
         </service>
 
         <service id="Stof\DoctrineExtensionsBundle\Uploadable\UploadableManager" alias="stof_doctrine_extensions.uploadable.manager" public="false" />
+
+        <service id="stof_doctrine_extensions.uploadable.configurator" class="Stof\DoctrineExtensionsBundle\Uploadable\ValidatorConfigurator" public="false">
+            <argument>%stof_doctrine_extensions.uploadable.validate_writable_directory%</argument>
+        </service>
     </services>
 </container>

--- a/StofDoctrineExtensionsBundle.php
+++ b/StofDoctrineExtensionsBundle.php
@@ -5,7 +5,6 @@ namespace Stof\DoctrineExtensionsBundle;
 use Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler\ValidateExtensionConfigurationPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Gedmo\Uploadable\Mapping\Validator;
 
 class StofDoctrineExtensionsBundle extends Bundle
 {
@@ -15,12 +14,5 @@ class StofDoctrineExtensionsBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new ValidateExtensionConfigurationPass());
-    }
-
-    public function boot()
-    {
-        if ($this->container->hasParameter('stof_doctrine_extensions.uploadable.validate_writable_directory')) {
-            Validator::$validateWritableDirectory = $this->container->getParameter('stof_doctrine_extensions.uploadable.validate_writable_directory');
-        }
     }
 }

--- a/Uploadable/ValidatorConfigurator.php
+++ b/Uploadable/ValidatorConfigurator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Stof\DoctrineExtensionsBundle\Uploadable;
+
+use Gedmo\Uploadable\Mapping\Validator;
+
+/**
+ * @internal
+ */
+class ValidatorConfigurator
+{
+    private $validateWritableDirectory;
+
+    /**
+     * @param bool $validateWritableDirectory
+     */
+    public function __construct($validateWritableDirectory)
+    {
+        $this->validateWritableDirectory = $validateWritableDirectory;
+    }
+
+    public function configure()
+    {
+        Validator::$validateWritableDirectory = $this->validateWritableDirectory;
+    }
+}


### PR DESCRIPTION
Instead of doing it on boot, which adds a small overhead for all requests (even when the uploadable extension is not enabled at all), the static property is now initialized based on the config at the time the UploadableListener gets instantiated.

Closes #331 