### PR TITLE
Added ability to customize the listener priorities

### DIFF
--- a/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -106,8 +106,8 @@ class StofDoctrineExtensionsExtension extends Extension
         );
 
         foreach ($configs as $name => $listeners) {
-            foreach ($listeners as $ext => $enabled) {
-                if (!$enabled) {
+            foreach ($listeners as $ext => $settingValue) {
+                if (false === $settingValue) {
                     continue;
                 }
 
@@ -120,6 +120,10 @@ class StofDoctrineExtensionsExtension extends Extension
 
                 if (isset($listenerPriorities[$ext])) {
                     $attributes['priority'] = $listenerPriorities[$ext];
+                }
+
+                if (is_numeric($settingValue)) {
+                    $attributes['priority'] = $settingValue;
                 }
 
                 $definition = $container->getDefinition(sprintf('stof_doctrine_extensions.listener.%s', $ext));

--- a/Tests/DependencyInjection/StofDoctrineExtensionsExtensionTest.php
+++ b/Tests/DependencyInjection/StofDoctrineExtensionsExtensionTest.php
@@ -101,4 +101,41 @@ class StofDoctrineExtensionsExtensionTest extends TestCase
         $this->assertCount(1, $def->getTag('doctrine.event_subscriber'));
         $this->assertCount(1, $def->getTag('doctrine_mongodb.odm.event_subscriber'));
     }
+
+    public function testConfigWithCustomListenerPriorities()
+    {
+        $extension = new StofDoctrineExtensionsExtension();
+        $container = new ContainerBuilder();
+
+        $config = array(
+            'orm' => array('default' => array(
+                'blameable' => 0,
+                'loggable' => -1,
+                'uploadable' => true,
+                'sortable' => false,
+            )),
+            'mongodb' => array('default' => array(
+                'blameable' => 0,
+                'loggable' => -1,
+                'uploadable' => true,
+                'sortable' => false,
+            )),
+        );
+
+        $extension->load(array($config), $container);
+
+        $def = $container->getDefinition('stof_doctrine_extensions.listener.blameable');
+        $this->assertTrue($def->hasTag('doctrine.event_subscriber'));
+        $this->assertArraySubset(array(array('priority' => 0)), $def->getTag('doctrine.event_subscriber'));
+
+        $def = $container->getDefinition('stof_doctrine_extensions.listener.loggable');
+        $this->assertTrue($def->hasTag('doctrine.event_subscriber'));
+        $this->assertArraySubset(array(array('priority' => -1)), $def->getTag('doctrine.event_subscriber'));
+
+        $def = $container->getDefinition('stof_doctrine_extensions.listener.uploadable');
+        $this->assertTrue($def->hasTag('doctrine.event_subscriber'));
+        $this->assertArraySubset(array(array('priority' => -5)), $def->getTag('doctrine.event_subscriber'));
+
+        $this->assertFalse($container->hasDefinition('stof_doctrine_extensions.listener.sortable'));
+    }
 }


### PR DESCRIPTION
by setting a numeric value in the config.

In the current implementation it is not possible to adjust the default/hardcoded listener priorities anyhow. Thus, as an example, the loggable listener creates a LogEntry before the blameable and/or timestample behaviors adjusts the respective fields.
If one wants to store those fields in the LogEntry as well there was no chance.

With this PR one set a numeric value to the configured behaviors in addition to just set it to `true`. This does not only allow to define custom priorities for those listeners which are registered without any, it also allows to override the hardcoded values of the `StofDoctrineExtensionsExtension` class.