### PR TITLE
Allowing doctrine-extensions v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/framework-bundle": "^4.3 || ^5.0",
-        "gedmo/doctrine-extensions": "^2.3.4"
+        "gedmo/doctrine-extensions": "^2.3.4 || ^3.0.0-beta2@beta"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4",


### PR DESCRIPTION
Fixes #413 and fixes #414 

Right now, people are having trouble installing this bundle because they are already locked at `doctrine/common` 3 or `doctrine/persistence` 2. You CAN work around this - #413. 

However, this will be fixed in  gedmo/doctrine-extensions v3, which is not installed yet. This will get the tests running so we can make sure all is good. Once gedmo/doctrine-extensions v3 is released, we can change the constraint to `^2.3.4 || ^3.0` and tag :).

Thanks!