### PR TITLE
fix conflict with easycorp/easyadmin-bundle

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -32,7 +32,7 @@ class LocaleListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            KernelEvents::REQUEST => 'onKernelRequest',
+            KernelEvents::REQUEST => ['onKernelRequest', 1],
         );
     }
 }


### PR DESCRIPTION
LocaleListener must call before easyadmin event.
Translatable does not work on the edit page in easyadmin.