### PR TITLE
Update BlameListener.php

### DIFF
--- a/src/EventListener/BlameListener.php
+++ b/src/EventListener/BlameListener.php
@@ -48,6 +48,9 @@ class BlameListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -29,6 +29,9 @@ class LocaleListener implements EventSubscriberInterface
         $this->translatableListener->setTranslatableLocale($event->getRequest()->getLocale());
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(

--- a/src/EventListener/LoggerListener.php
+++ b/src/EventListener/LoggerListener.php
@@ -48,6 +48,9 @@ class LoggerListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(


### PR DESCRIPTION
Ref Symfony v5.4 profiler log deprecations

```
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Stof\DoctrineExtensionsBundle\EventListener\BlameListener" now to avoid errors or add an explicit @return annotation to suppress this message.
```