### PR TITLE
feat: Support timestampable and blameable for loggable

### DIFF
--- a/src/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/src/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -102,6 +102,8 @@ class StofDoctrineExtensionsExtension extends Extension
         $listenerPriorities = array(
             'translatable' => -10,
             'loggable' => 5,
+            'timestampable' => 10,
+            'blameable' => 10,
             'uploadable' => -5,
         );
 


### PR DESCRIPTION
By setting this priorities for the timestampable and blameable listener, the loggable listener will be called after them and also receives the changes made by the timestampable and blameable listener.