### PR TITLE
chore: add ci tests for php 8.2, bump github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
             - name: Validate composer.json
               run: composer validate --strict --no-check-lock
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+                php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
                 name_suffix: ['']
                 stability: ['stable']
                 composer_flags: ['']
@@ -37,7 +37,7 @@ jobs:
                       composer_flags: ''
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
 
             -   uses: shivammathur/setup-php@v2
                 with:


### PR DESCRIPTION
Will fix deprecations for Node 12 on github action runs.