### PR TITLE
Fix symfony 6.3 return type deprecations

### DIFF
--- a/src/DependencyInjection/Compiler/ValidateExtensionConfigurationPass.php
+++ b/src/DependencyInjection/Compiler/ValidateExtensionConfigurationPass.php
@@ -18,6 +18,8 @@ class ValidateExtensionConfigurationPass implements CompilerPassInterface
      * compiler pass.
      *
      * @param ContainerBuilder $container
+     *
+     * @return void
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/src/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -14,6 +14,9 @@ class StofDoctrineExtensionsExtension extends Extension
     private $entityManagers   = array();
     private $documentManagers = array();
 
+    /**
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $processor = new Processor();

--- a/src/StofDoctrineExtensionsBundle.php
+++ b/src/StofDoctrineExtensionsBundle.php
@@ -10,6 +10,8 @@ class StofDoctrineExtensionsBundle extends Bundle
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function build(ContainerBuilder $container)
     {


### PR DESCRIPTION
> Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Stof\DoctrineExtensionsBundle\DependencyInjection\StofDoctrineExtensionsExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

> Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler\ValidateExtensionConfigurationPass" now to avoid errors or add an explicit @return annotation to suppress this message.

> User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle" now to avoid errors or add an explicit @return annotation to suppress this message.