### PR TITLE
Register listeners instead of subscribers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/dependency-injection": "^4.4 || ^5.2 || ^6.0",
         "symfony/event-dispatcher": "^4.4 || ^5.2 || ^6.0",
         "symfony/http-kernel": "^4.4 || ^5.2 || ^6.0",
-        "gedmo/doctrine-extensions": "^2.3.4 || ^3.0.0"
+        "gedmo/doctrine-extensions": "^2.3.12 || ^3.0.0"
     },
     "require-dev": {
         "symfony/mime": "^4.4 || ^5.2 || ^6.0",


### PR DESCRIPTION
Symfony 6.3 deprecated the registration of Doctrine subscribers because they cannot be lazy-loaded properly.
The CI will ensure that the list of events is in sync with the library.

Closes https://github.com/stof/StofDoctrineExtensionsBundle/issues/450