### PR TITLE
Add options: force_use_attribute_reader, separate_xml_mapping

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,8 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                     ->defaultValue('en')
                 ->end()
+                ->booleanNode('force_use_attribute_reader')->defaultFalse()->end()
+                ->booleanNode('separate_xml_mapping')->defaultFalse()->end()
                 ->booleanNode('translation_fallback')->defaultFalse()->end()
                 ->booleanNode('persist_default_translation')->defaultFalse()->end()
                 ->booleanNode('skip_translation_on_load')->defaultFalse()->end()

--- a/src/DependencyInjection/StofDoctrineExtensionsExtension.php
+++ b/src/DependencyInjection/StofDoctrineExtensionsExtension.php
@@ -101,6 +101,9 @@ class StofDoctrineExtensionsExtension extends Extension
         $this->entityManagers = $this->processObjectManagerConfigurations($config['orm'], $container, $loader, $loaded, 'doctrine.event_listener');
         $this->documentManagers = $this->processObjectManagerConfigurations($config['mongodb'], $container, $loader, $loaded, 'doctrine_mongodb.odm.event_listener');
 
+
+        $container->setParameter('stof_doctrine_extensions.force_use_attribute_reader', $config['force_use_attribute_reader']);
+        $container->setParameter('stof_doctrine_extensions.separate_xml_mapping', $config['separate_xml_mapping']);
         $container->setParameter('stof_doctrine_extensions.default_locale', $config['default_locale']);
         $container->setParameter('stof_doctrine_extensions.translation_fallback', $config['translation_fallback']);
         $container->setParameter('stof_doctrine_extensions.persist_default_translation', $config['persist_default_translation']);

--- a/src/Resources/config/blameable.xml
+++ b/src/Resources/config/blameable.xml
@@ -16,6 +16,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
 
         <service id="stof_doctrine_extensions.event_listener.blame" class="%stof_doctrine_extensions.event_listener.blame.class%">

--- a/src/Resources/config/ip_traceable.xml
+++ b/src/Resources/config/ip_traceable.xml
@@ -12,6 +12,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
 
         <service id="stof_doctrine_extensions.event_listener.ip_trace" class="Stof\DoctrineExtensionsBundle\EventListener\IpTraceListener" public="false">

--- a/src/Resources/config/loggable.xml
+++ b/src/Resources/config/loggable.xml
@@ -16,6 +16,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
 
         <service id="stof_doctrine_extensions.event_listener.logger" class="%stof_doctrine_extensions.event_listener.logger.class%">

--- a/src/Resources/config/reference_integrity.xml
+++ b/src/Resources/config/reference_integrity.xml
@@ -15,6 +15,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Resources/config/sluggable.xml
+++ b/src/Resources/config/sluggable.xml
@@ -15,6 +15,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Resources/config/softdeleteable.xml
+++ b/src/Resources/config/softdeleteable.xml
@@ -15,6 +15,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Resources/config/sortable.xml
+++ b/src/Resources/config/sortable.xml
@@ -15,6 +15,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Resources/config/timestampable.xml
+++ b/src/Resources/config/timestampable.xml
@@ -15,6 +15,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Resources/config/translatable.xml
+++ b/src/Resources/config/translatable.xml
@@ -31,6 +31,12 @@
             <call method="setSkipOnLoad">
                 <argument>%stof_doctrine_extensions.skip_translation_on_load%</argument>
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
 
         <service id="stof_doctrine_extensions.event_listener.locale" class="%stof_doctrine_extensions.event_listener.locale.class%">

--- a/src/Resources/config/tree.xml
+++ b/src/Resources/config/tree.xml
@@ -15,6 +15,12 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Resources/config/uploadable.xml
+++ b/src/Resources/config/uploadable.xml
@@ -21,9 +21,14 @@
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" />
             </call>
-
             <call method="setDefaultFileInfoClass">
                 <argument>%stof_doctrine_extensions.uploadable.default_file_info.class%</argument>
+            </call>
+            <call method="setForceUseAttributeReader">
+                <argument>%stof_doctrine_extensions.force_use_attribute_reader%</argument>
+            </call>
+            <call method="setSeparateXmlMapping">
+                <argument>%stof_doctrine_extensions.separate_xml_mapping%</argument>
             </call>
         </service>
 


### PR DESCRIPTION
Closes https://github.com/doctrine-extensions/DoctrineExtensions/issues/2613 and https://github.com/doctrine-extensions/DoctrineExtensions/issues/2318

To set up separate mapping of Gedmo/Doctrine
See details here: https://github.com/doctrine-extensions/DoctrineExtensions/pull/2657