### PR TITLE
Allow the bundle to work without Annotation Reader enabled in Symfony

### DIFF
--- a/src/Resources/config/blameable.xml
+++ b/src/Resources/config/blameable.xml
@@ -14,7 +14,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
 

--- a/src/Resources/config/ip_traceable.xml
+++ b/src/Resources/config/ip_traceable.xml
@@ -10,7 +10,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
 

--- a/src/Resources/config/loggable.xml
+++ b/src/Resources/config/loggable.xml
@@ -14,7 +14,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
 

--- a/src/Resources/config/reference_integrity.xml
+++ b/src/Resources/config/reference_integrity.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/sluggable.xml
+++ b/src/Resources/config/sluggable.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/softdeleteable.xml
+++ b/src/Resources/config/softdeleteable.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/sortable.xml
+++ b/src/Resources/config/sortable.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/timestampable.xml
+++ b/src/Resources/config/timestampable.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/translatable.xml
+++ b/src/Resources/config/translatable.xml
@@ -14,7 +14,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
             <call method="setDefaultLocale">
                 <argument>%stof_doctrine_extensions.default_locale%</argument>

--- a/src/Resources/config/tree.xml
+++ b/src/Resources/config/tree.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/uploadable.xml
+++ b/src/Resources/config/uploadable.xml
@@ -19,7 +19,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" />
+                <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>
 
             <call method="setDefaultFileInfoClass">


### PR DESCRIPTION
Fixes #459 