### PR TITLE
feat: allow symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "symfony/cache": "^5.4 || ^6.0",
-        "symfony/config": "^5.4 || ^6.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0",
-        "symfony/event-dispatcher": "^5.4 || ^6.0",
-        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
         "gedmo/doctrine-extensions": "^3.5.0"
     },
     "require-dev": {
-        "symfony/mime": "^5.4 || ^6.0",
-        "symfony/phpunit-bridge": "^v5.4 || ^6.0",
-        "symfony/security-core": "^5.4 || ^6.0"
+        "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^v5.4 || ^6.0 || ^7.0",
+        "symfony/security-core": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "to use the ORM extensions",


### PR DESCRIPTION
@tacman
https://github.com/stof/StofDoctrineExtensionsBundle/issues/462

Test-Run with symfony 7.0 beta. https://github.com/Chris53897/StofDoctrineExtensionsBundle/actions/runs/6731724629/job/18296991212
PR: https://github.com/doctrine-extensions/DoctrineExtensions/pull/2721

But symfony/cache is limited to 6.4.x-dev due to [gedmo/doctrine-extensions](https://packagist.org/packages/gedmo/)