### PR TITLE
Add the configuration for the Clock integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-        "gedmo/doctrine-extensions": "^3.5.0"
+        "gedmo/doctrine-extensions": "^3.15.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",

--- a/src/Resources/config/softdeleteable.xml
+++ b/src/Resources/config/softdeleteable.xml
@@ -12,6 +12,9 @@
             <call method="setCacheItemPool">
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
+            <call method="setClock">
+                <argument type="service" id="clock" on-invalid="ignore" />
+            </call>
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>

--- a/src/Resources/config/timestampable.xml
+++ b/src/Resources/config/timestampable.xml
@@ -12,6 +12,9 @@
             <call method="setCacheItemPool">
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
+            <call method="setClock">
+                <argument type="service" id="clock" on-invalid="ignore" />
+            </call>
             <call method="setAnnotationReader">
                 <argument type="service" id="annotation_reader" on-invalid="ignore" />
             </call>


### PR DESCRIPTION
When the `clock` service is defined (which is done by FrameworkBundle when `symfony/clock` is installed), it will be injected in the listeners supporting a clock integration.

Closes https://github.com/stof/StofDoctrineExtensionsBundle/issues/469