### PR TITLE
Drop support for PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+                php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
                 name_suffix: ['']
                 stability: ['stable']
                 composer_flags: ['']
                 include:
-                    - php: '7.2'
+                    - php: '7.4'
                       name_suffix: ' (lowest deps)'
                       stability: 'stable'
                       composer_flags: '--prefer-lowest'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
The extensions have bumped their min PHP version to 7.4, so I'm doing the same in the bundle.