### PR TITLE
Inject an AttributeReader when annotations are disabled

### DIFF
--- a/src/DependencyInjection/Compiler/ReaderPass.php
+++ b/src/DependencyInjection/Compiler/ReaderPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler;
+
+use Gedmo\Mapping\Driver\AttributeReader;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class ReaderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->has('annotation_reader')) {
+            $container->setAlias('.stof_doctrine_extensions.reader', new Alias('annotation_reader', false));
+
+            return;
+        }
+
+        if (\PHP_VERSION_ID >= 80000) {
+            $container->register('.stof_doctrine_extensions.reader', AttributeReader::class);
+        }
+    }
+}

--- a/src/Resources/config/blameable.xml
+++ b/src/Resources/config/blameable.xml
@@ -14,7 +14,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
 

--- a/src/Resources/config/ip_traceable.xml
+++ b/src/Resources/config/ip_traceable.xml
@@ -10,7 +10,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
 

--- a/src/Resources/config/loggable.xml
+++ b/src/Resources/config/loggable.xml
@@ -14,7 +14,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
 

--- a/src/Resources/config/reference_integrity.xml
+++ b/src/Resources/config/reference_integrity.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/sluggable.xml
+++ b/src/Resources/config/sluggable.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/softdeleteable.xml
+++ b/src/Resources/config/softdeleteable.xml
@@ -16,7 +16,7 @@
                 <argument type="service" id="clock" on-invalid="ignore" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/sortable.xml
+++ b/src/Resources/config/sortable.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/timestampable.xml
+++ b/src/Resources/config/timestampable.xml
@@ -16,7 +16,7 @@
                 <argument type="service" id="clock" on-invalid="ignore" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/translatable.xml
+++ b/src/Resources/config/translatable.xml
@@ -14,7 +14,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
             <call method="setDefaultLocale">
                 <argument>%stof_doctrine_extensions.default_locale%</argument>

--- a/src/Resources/config/tree.xml
+++ b/src/Resources/config/tree.xml
@@ -13,7 +13,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
         </service>
     </services>

--- a/src/Resources/config/uploadable.xml
+++ b/src/Resources/config/uploadable.xml
@@ -19,7 +19,7 @@
                 <argument type="service" id="stof_doctrine_extensions.metadata_cache" />
             </call>
             <call method="setAnnotationReader">
-                <argument type="service" id="annotation_reader" on-invalid="ignore" />
+                <argument type="service" id=".stof_doctrine_extensions.reader" on-invalid="ignore" />
             </call>
 
             <call method="setDefaultFileInfoClass">

--- a/src/StofDoctrineExtensionsBundle.php
+++ b/src/StofDoctrineExtensionsBundle.php
@@ -2,6 +2,7 @@
 
 namespace Stof\DoctrineExtensionsBundle;
 
+use Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler\ReaderPass;
 use Stof\DoctrineExtensionsBundle\DependencyInjection\Compiler\ValidateExtensionConfigurationPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -16,5 +17,6 @@ class StofDoctrineExtensionsBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new ValidateExtensionConfigurationPass());
+        $container->addCompilerPass(new ReaderPass());
     }
 }


### PR DESCRIPTION
This avoids triggering the fallback path of instantiating an (uncached) annotation reader in the extensions in case annotations are disabled in FrameworkBundle but the `doctrine/annotations` package is still installed.

Closes #481