### PR TITLE
Bump gedmo/doctrine-extensions to v3.16 for compatibility with ORM 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-        "gedmo/doctrine-extensions": "^3.15.0"
+        "gedmo/doctrine-extensions": "^3.16.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
DoctrineExtensions [3.16](https://github.com/doctrine-extensions/DoctrineExtensions/releases/tag/v3.16.0) has been released. Mainly adds supports for ORM 3.0 which should fix issues such as https://github.com/stof/StofDoctrineExtensionsBundle/issues/480 and https://github.com/stof/StofDoctrineExtensionsBundle/issues/478