### PR TITLE
feat: handling sf deprecation suppression

### DIFF
--- a/src/EventListener/BlameListener.php
+++ b/src/EventListener/BlameListener.php
@@ -48,7 +48,10 @@ class BlameListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/EventListener/BlameListener.php
+++ b/src/EventListener/BlameListener.php
@@ -4,7 +4,6 @@ namespace Stof\DoctrineExtensionsBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -51,7 +50,7 @@ class BlameListener implements EventSubscriberInterface
     /**
      * @return array<string, string>
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/EventListener/IpTraceListener.php
+++ b/src/EventListener/IpTraceListener.php
@@ -36,7 +36,7 @@ final class IpTraceListener implements EventSubscriberInterface
     /**
      * @return array<string, array<int, int|string>>
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             KernelEvents::REQUEST => ['onKernelRequest', 500],

--- a/src/EventListener/IpTraceListener.php
+++ b/src/EventListener/IpTraceListener.php
@@ -33,6 +33,9 @@ final class IpTraceListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @return array<string, array<int, int|string>>
+     */
     public static function getSubscribedEvents(): array
     {
         return array(

--- a/src/EventListener/IpTraceListener.php
+++ b/src/EventListener/IpTraceListener.php
@@ -36,7 +36,7 @@ final class IpTraceListener implements EventSubscriberInterface
     /**
      * @return array<string, array<int, int|string>>
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()
     {
         return array(
             KernelEvents::REQUEST => ['onKernelRequest', 500],

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -29,7 +29,10 @@ class LocaleListener implements EventSubscriberInterface
         $this->translatableListener->setTranslatableLocale($event->getRequest()->getLocale());
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -32,7 +32,7 @@ class LocaleListener implements EventSubscriberInterface
     /**
      * @return array<string, string>
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/EventListener/LoggerListener.php
+++ b/src/EventListener/LoggerListener.php
@@ -58,7 +58,7 @@ class LoggerListener implements EventSubscriberInterface
     /**
      * @return array<string, string>
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/EventListener/LoggerListener.php
+++ b/src/EventListener/LoggerListener.php
@@ -55,7 +55,10 @@ class LoggerListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',


### PR DESCRIPTION
This PR basically suppress the warnings around `Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()`.

According to @stof replies [here](https://github.com/stof/StofDoctrineExtensionsBundle/pull/476) it should be the perfect tradeoff.