### PR TITLE
Prevent running into metadata driver error (Symfony 6.4)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -17,25 +17,25 @@ to register their mapping in Doctrine when you want to use them.
                 default:
                     mappings:
                         gedmo_translatable:
-                            type: annotation
+                            type: annotation # only on Symfony < 6.4
                             prefix: Gedmo\Translatable\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translatable/Entity"
                             alias: GedmoTranslatable # (optional) it will default to the name set for the mapping
                             is_bundle: false
                         gedmo_translator:
-                            type: annotation
+                            type: annotation # only on Symfony < 6.4
                             prefix: Gedmo\Translator\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translator/Entity"
                             alias: GedmoTranslator # (optional) it will default to the name set for the mapping
                             is_bundle: false
                         gedmo_loggable:
-                            type: annotation
+                            type: annotation # only on Symfony < 6.4
                             prefix: Gedmo\Loggable\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Loggable/Entity"
                             alias: GedmoLoggable # (optional) it will default to the name set for the mapping
                             is_bundle: false
                         gedmo_tree:
-                            type: annotation
+                            type: annotation # only on Symfony < 6.4
                             prefix: Gedmo\Tree\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Tree/Entity"
                             alias: GedmoTree # (optional) it will default to the name set for the mapping


### PR DESCRIPTION
After [configuring the bundle](https://symfony.com/bundles/StofDoctrineExtensionsBundle/current/configuration.html#add-the-extensions-to-your-mapping) on Symfony 6.4, when doing `php bin/console doctrine:schema:update --dump-sql` I received following error:

> Can only configure "xml", "yml", "php", "staticphp" or "attribute" through the DoctrineBundle. Use your own bundle to configure other metadata drivers. You can register them by adding a new driver to the "doctrine.orm.default_metadata_driver" service definition.

According to [Symfony docs](https://symfony.com/doc/6.4/reference/configuration/doctrine.html#type), annotations are deprecated since Symfony 6.4.
By removing the lines `type: annotation`, the translating worked so far.