### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -17,25 +17,25 @@ to register their mapping in Doctrine when you want to use them.
                 default:
                     mappings:
                         gedmo_translatable:
-                            type: annotation
+                            type: attribute
                             prefix: Gedmo\Translatable\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translatable/Entity"
                             alias: GedmoTranslatable # (optional) it will default to the name set for the mapping
                             is_bundle: false
                         gedmo_translator:
-                            type: annotation
+                            type: attribute
                             prefix: Gedmo\Translator\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Translator/Entity"
                             alias: GedmoTranslator # (optional) it will default to the name set for the mapping
                             is_bundle: false
                         gedmo_loggable:
-                            type: annotation
+                            type: attribute
                             prefix: Gedmo\Loggable\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Loggable/Entity"
                             alias: GedmoLoggable # (optional) it will default to the name set for the mapping
                             is_bundle: false
                         gedmo_tree:
-                            type: annotation
+                            type: attribute
                             prefix: Gedmo\Tree\Entity
                             dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Tree/Entity"
                             alias: GedmoTree # (optional) it will default to the name set for the mapping


### PR DESCRIPTION
Entities in the bundle have both annotations and attributes. When annotation is set in config, this error is thrown

In AbstractDoctrineExtension.php line 229:
                                                                               
  Can only configure "xml", "yml", "php", "staticphp" or "attribute" through   
  the DoctrineBundle. Use your own bundle to configure other metadata drivers  
  . You can register them by adding a new driver to the "doctrine.orm.default  
  _metadata_driver" service definition.