### PR TITLE
Use a locale-aware service to configure the translatable listener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,13 @@
     ],
     "require": {
         "php": "^8.1",
+        "gedmo/doctrine-extensions": "^3.20.0",
         "symfony/cache": "^6.4 || ^7.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0",
-        "gedmo/doctrine-extensions": "^3.20.0"
+        "symfony/translation-contracts": "^2.5 || ^3.5"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -8,9 +8,11 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * This listeners sets the current locale for the TranslatableListener
+ * This listener sets the current locale for the TranslatableListener
  *
  * @author Christophe COEVOET
+ *
+ * @deprecated since 1.14. Use the LocaleSynchronizer instead.
  */
 class LocaleListener implements EventSubscriberInterface
 {

--- a/src/Resources/config/translatable.xml
+++ b/src/Resources/config/translatable.xml
@@ -33,9 +33,14 @@
             </call>
         </service>
 
-        <service id="stof_doctrine_extensions.event_listener.locale" class="%stof_doctrine_extensions.event_listener.locale.class%">
+        <service id="stof_doctrine_extensions.tool.locale_synchronizer" class="Stof\DoctrineExtensionsBundle\Tool\LocaleSynchronizer" public="false">
             <argument type="service" id="stof_doctrine_extensions.listener.translatable" />
-            <tag name="kernel.event_subscriber" />
+            <tag name="kernel.locale_aware" />
+        </service>
+
+        <service id="stof_doctrine_extensions.event_listener.locale" class="%stof_doctrine_extensions.event_listener.locale.class%">
+            <deprecated package="stof/doctrine-extensions-bundle" version="1.14">The "%service_id%" service is deprecated and will be removed in 2.0. The "stof_doctrine_extensions.tool.locale_synchronizer" service should be used to provide the user instead.</deprecated>
+            <argument type="service" id="stof_doctrine_extensions.listener.translatable" />
         </service>
     </services>
 </container>

--- a/src/Tool/LocaleSynchronizer.php
+++ b/src/Tool/LocaleSynchronizer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Stof\DoctrineExtensionsBundle\Tool;
+
+use Gedmo\Translatable\TranslatableListener;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+
+/**
+ * @internal
+ */
+final class LocaleSynchronizer implements LocaleAwareInterface
+{
+    private TranslatableListener $listener;
+
+    public function __construct(TranslatableListener $listener)
+    {
+        $this->listener = $listener;
+    }
+
+    public function setLocale(string $locale): void
+    {
+        $this->listener->setTranslatableLocale($locale);
+    }
+
+    public function getLocale(): string
+    {
+        return $this->listener->getListenerLocale();
+    }
+}


### PR DESCRIPTION
Registering it in the LocaleSwitcher of Symfony has multiple benefits:
- it allows respecting the locale when it is switched in non-request context (or after the listener that was running for request contexts), for instance in commands or in queue consumers
- it avoids leaking the locale of a request to the beginning of the processing of the next one when using Frankenphp in worker mode (or as the LocaleSwitcher of Symfony resets the locale to the default locale of the project when necessary.