### PR TITLE
Update softdeleteable documentation with the correct name for the filter

### DIFF
--- a/docs/softdeleteable-filter.rst
+++ b/docs/softdeleteable-filter.rst
@@ -31,4 +31,4 @@ To disable the behavior, e.g. for admin users who may see deleted items,
 disable the filter. Here is an example::
 
     $filters = $em->getFilters();
-    $filters->disable('softdeleteable');
+    $filters->disable('soft_delete');


### PR DESCRIPTION
I just saw the name for the filter in the documentation was not accurate, I had the error in my code on SF 7.3, after dump, I saw the correct name for the filter : 'soft_delete'.