### PR TITLE
ci: add tests for PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: shivammathur/setup-php@v2
             - name: Validate composer.json
               run: composer validate --strict --no-check-lock
@@ -19,7 +19,7 @@ jobs:
         name: Static analysis
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -41,7 +41,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.1', '8.2', '8.3', '8.4' ]
+                php: [ '8.1', '8.2', '8.3', '8.4', '8.5']
                 name_suffix: ['']
                 stability: ['stable']
                 composer_flags: ['']
@@ -56,7 +56,7 @@ jobs:
                       composer_flags: ''
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -   uses: shivammathur/setup-php@v2
                 with:


### PR DESCRIPTION
Updated GitHub Actions workflow to use checkout@v5 and added PHP 8.5 to the matrix.