### PR TITLE
Fix class parameter

### DIFF
--- a/src/Resources/config/uploadable.php
+++ b/src/Resources/config/uploadable.php
@@ -11,7 +11,7 @@ use Stof\DoctrineExtensionsBundle\Uploadable\ValidatorConfigurator;
 return static function (ContainerConfigurator $container): void {
     $container->parameters()
         ->set('stof_doctrine_extensions.listener.uploadable.class', UploadableListener::class)
-        ->set('stof_doctrine_extensions.listener.uploadable.manager.class', UploadableManager::class)
+        ->set('stof_doctrine_extensions.uploadable.manager.class', UploadableManager::class)
         ->set('stof_doctrine_extensions.uploadable.mime_type_guesser.class', MimeTypeGuesserAdapter::class)
         ->set('stof_doctrine_extensions.uploadable.default_file_info.class', UploadedFileInfo::class)
     ;


### PR DESCRIPTION
I just updated to the latest 1.15 version and while refreshing the cache, I got an error telling me that the parameter `stof_doctrine_extensions.uploadable.manager.class` was not found. I dig a bit to the configuration update.
It seems that the script produced an error as the parameter indeed did not exists.
I managed to retrieve the correct one to rename, hopefully.

A quick release would be appreciated, I hope there is no other configuration with issue.
I was able to test that in my project where I use tree, timestampable, sluggable, softdeletable and uploadable. This is the only one which produces an error.

I stay on the latest 1.14 for now.

Let me know if/how I can improve the tests.

Thank you! @stof 