### PR TITLE
Fix service definition for the uploadable manager

### DIFF
--- a/src/Resources/config/uploadable.php
+++ b/src/Resources/config/uploadable.php
@@ -33,9 +33,6 @@ return static function (ContainerConfigurator $container): void {
                 service('stof_doctrine_extensions.listener.uploadable'),
                 param('stof_doctrine_extensions.uploadable.default_file_info.class')
             ])
-            ->call('setCacheItemPool', [service('stof_doctrine_extensions.metadata_cache')])
-            ->call('setAnnotationReader', [service('.stof_doctrine_extensions.reader')->ignoreOnInvalid()])
-            ->call('setDefaultFileInfoClass', [param('stof_doctrine_extensions.uploadable.default_file_info.class')])
         ->alias(UploadableManager::class, 'stof_doctrine_extensions.uploadable.manager')
 
         ->set('stof_doctrine_extensions.uploadable.configurator', ValidatorConfigurator::class)


### PR DESCRIPTION
After an upgrade of te bundle from v1.14.x to 1.15.2, i keep getting the following error on a cache:clear:
`You have requested a non-existent service "stof_doctrine_extensions.uploadable_manager".`

After digging a bit, i found  a typo in the alias for the uploadableManager `src/Resources/uploadable.php`.
At line 31 the service is defined as `stof_doctrine_extensions.uploadable.manager` (with a dot), but line 39, the reference called is `stof_doctrine_extensions.uploadable_manager` (with an underscore). 

Just after that, I run into another error due to the incorrect call of methods `setCacheItemPool`,  `setAnnotationReader` and `setDefaultFileInfoClass` on the manager, which are only existant in the listener and has nothing to do with the manager.

A quick release would be very appreciated since Uploadable is not useable at all without these changes