### PR TITLE
Fix the autowiring alias for the uploadable manager

### DIFF
--- a/src/Resources/config/uploadable.php
+++ b/src/Resources/config/uploadable.php
@@ -36,7 +36,7 @@ return static function (ContainerConfigurator $container): void {
             ->call('setCacheItemPool', [service('stof_doctrine_extensions.metadata_cache')])
             ->call('setAnnotationReader', [service('.stof_doctrine_extensions.reader')->ignoreOnInvalid()])
             ->call('setDefaultFileInfoClass', [param('stof_doctrine_extensions.uploadable.default_file_info.class')])
-        ->alias(UploadableManager::class, 'stof_doctrine_extensions.uploadable_manager')
+        ->alias(UploadableManager::class, 'stof_doctrine_extensions.uploadable.manager')
 
         ->set('stof_doctrine_extensions.uploadable.configurator', ValidatorConfigurator::class)
             ->args([


### PR DESCRIPTION
Fixes typo `stof_doctrine_extensions.uploadable_manager` with `stof_doctrine_extensions.uploadable.manager`

Fixes #523 